### PR TITLE
[#10] Add dependency injection container using python-inject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 # custom
 .idea/
 *.ipynb
+test.py

--- a/mas/container.py
+++ b/mas/container.py
@@ -1,0 +1,34 @@
+import inject
+
+from mas.database.database_connection import DatabaseConnection
+from mas.database.mysql_connection import MySQLConnection
+from mas.utils.config import Config
+
+
+class Initializer:
+    """
+    This class is responsible for initializing the application with necessary dependencies.
+
+    Args:
+        phase (str): The current phase of the application (e.g. development, production)
+    """
+
+    def __init__(self, phase: str):
+        self.phase = phase
+        self.config = Config(phase)
+        inject.configure(self._bind)
+
+    def _bind(self, binder: inject.Binder):
+        """
+        Binds the necessary dependencies for the application.
+
+        Args:
+            binder (inject.Binder): The binder object to bind the dependencies.
+        """
+
+        # 1. bind config
+        binder.bind(Config, self.config)
+
+        # 2. bind database connection
+        database_connection = MySQLConnection(self.config)
+        binder.bind(DatabaseConnection, database_connection)

--- a/mas/database/database_connection.py
+++ b/mas/database/database_connection.py
@@ -2,9 +2,12 @@ import os
 from abc import ABC, abstractmethod
 
 from cryptography.fernet import Fernet
+from sqlalchemy.ext.declarative import declarative_base
 
 from mas.utils.config import Config
 from mas.utils.const import DATABASE_DRIVER_CLASS
+
+Base = declarative_base()
 
 
 class DatabaseConnection(ABC):

--- a/mas/database/mysql_connection.py
+++ b/mas/database/mysql_connection.py
@@ -1,8 +1,20 @@
+from asyncio import current_task
+from contextlib import AbstractContextManager, asynccontextmanager
+from logging import getLogger
+from typing import Callable
+
 from sqlalchemy import NullPool
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_scoped_session,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from mas.database.database_connection import DatabaseConnection
 from mas.utils.config import Config
+
+logger = getLogger()
 
 
 class MySQLConnection(DatabaseConnection):
@@ -17,34 +29,47 @@ class MySQLConnection(DatabaseConnection):
     def __init__(self, config: Config, dbms_name: str = "mysql"):
         super().__init__(config, dbms_name)
 
-        self.engine = None
-        self.async_session = None
-
-    async def get_session(self) -> async_sessionmaker[AsyncSession]:
-        """
-        Returns an async SQLAlchemy session object to interact with the database.
-
-        Returns:
-            AsyncSession: An async SQLAlchemy session object to interact with the database.
-        """
-        return self.async_session
+        self._engine = None
+        self._session_factory = None
 
     async def connect_db(self):
         """
         Connects to the MySQL database.
         """
-        self.engine = create_async_engine(
+        self._engine = create_async_engine(
             self.database_url,
             echo=True,
             future=True,
             poolclass=NullPool,
         )
-        self.async_session = async_sessionmaker(
-            bind=self.engine, class_=AsyncSession, expire_on_commit=False
+        self._session_factory = async_scoped_session(
+            session_factory=async_sessionmaker(
+                bind=self._engine, class_=AsyncSession, expire_on_commit=False
+            ),
+            scopefunc=current_task,
         )
 
     async def disconnect_db(self):
         """
         Disconnects from the MySQL database.
         """
-        await self.engine.dispose()
+        await self._engine.dispose()
+
+    @asynccontextmanager
+    async def get_session(self) -> Callable[..., AbstractContextManager[AsyncSession]]:
+        """
+        Returns an async SQLAlchemy session object to interact with the database.
+
+        Returns:
+            AsyncSession: An async SQLAlchemy session object to interact with the database.
+        """
+        session: AsyncSession = self._session_factory()
+        try:
+            yield session
+        except Exception:
+            logger.exception("Session rollback because of exception")
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+            await self._session_factory.remove()

--- a/mas/mas_application.py
+++ b/mas/mas_application.py
@@ -1,10 +1,3 @@
-from fastapi import FastAPI
+from mas.utils.controller_utils import create_app
 
-from mas.utils.controller_utils import get_controllers
-
-app = FastAPI()
-modules = get_controllers("./")
-
-for module in modules:
-    router = module.router
-    app.include_router(router)
+app = create_app()

--- a/mas/utils/controller_utils.py
+++ b/mas/utils/controller_utils.py
@@ -2,25 +2,65 @@ import importlib
 import os
 from glob import glob
 
+from fastapi import FastAPI
+
+from mas.container import Initializer
+
+
+def create_app() -> FastAPI:
+    """
+    Creates a FastAPI application, initializes it with the local configuration, and includes all routers found in the
+    project directory.
+
+    Returns:
+        FastAPI: A new FastAPI application.
+    """
+    Initializer("local")
+
+    app = FastAPI()
+    modules = get_controllers("./")
+
+    for module in modules:
+        router = module.router
+        app.include_router(router)
+
+    return app
+
 
 def get_controllers(project_path: str):
     """
+    Finds all modules with a "_controller.py" file in the given project directory.
 
     Args:
-        project_path (str): path of this project
+        project_path (str): The root directory of the project.
+    """
+    module_names = get_module_names(project_path, "controller")
+
+    return [importlib.import_module(module_name) for module_name in module_names]
+
+
+def get_module_names(project_path: str, pattern: str) -> list[str]:
+    """
+    Recursively searches the given project directory for subdirectories containing a specific pattern.
+
+    Args:
+        project_path (str): The root directory of the project.
+        pattern (str): The subdirectory name pattern to search for (e.g. "controller").
+
+    Returns:
+        list[str]: A list of module names as strings.
     """
     module_names = []
-
     for root, dirs, files in os.walk(project_path):
         for directory in dirs:
-            controller_dir = os.path.join(root, directory, "controller")
+            controller_dir = os.path.join(root, directory, pattern)
             if os.path.isdir(controller_dir):
                 for controller_file in glob(
-                    os.path.join(controller_dir, "*_controller.py")
+                    os.path.join(controller_dir, f"*_{pattern}.py")
                 ):
                     relative_path = os.path.relpath(controller_file, start=project_path)
                     relative_path = relative_path.replace("/", ".").replace("\\", ".")
                     module_name = relative_path.rstrip(".py")
                     module_names.append(module_name)
 
-    return [importlib.import_module(module_name) for module_name in module_names]
+    return module_names

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ SQLAlchemy==2.0.8
 aiomysql==0.1.1
 greenlet==2.0.2
 cryptography==40.0.1
+Inject==4.3.1


### PR DESCRIPTION
## Title
- python-inject를 활용한 의존관계 주입 컨테이너 추가

## Description
- 대표적으로 사용되는 python의 의존관계 주입 라이브러리는 아래 3가지 입니다. (order by star)
  - [dependency-injector](https://python-dependency-injector.ets-labs.org/)
  - [python-injector](https://github.com/python-injector/injector)
  - [python-inject](https://github.com/ivankorobkov/python-inject)
- 우선, 그 어느 라이브러리도 스프링만큼 편하게 DI를 해주진 않습니다 :(
- 아래와 같은 이유로 3번째 라이브러리 **python-inject**를 활용했습니다.
  1. 많이 사용해봤습니다. 사내 프로젝트에서 사용 중인 라이브러리입니다.
  2. 사용하기 쉽고 직관적입니다.
  3. 인스턴스를 싱글톤으로 관리하기 용이합니다. 라이브러리에 종속적이지 않은 듯한 코드를 작성할 수 있습니다.
- 아래와 같은 이유로 **dependency-injector**는 사용하지 않았습니다.
  1. 직접 사용해본 결과, 이 프로젝트가 사용하기에는 오버 스펙이란 느낌을 받았습니다. 일부분의 기능만 활용할 것 같습니다.
  2. 싱글톤 컨테이너의 사용이 FastAPI 친화적이지 않습니다. 짧게 사용해봤기 때문에 잘못 사용하는 것일 수도 있으나, FactoryProvider를 사용해야만 wiring 기능을 활용할 수 있는 것 같습니다. 이 프로젝트는 싱글톤 패턴 기반의 DI를 지향합니다.
- 그러나, python-inject는 더 이상 유지보수되고 있지 않습니다.
  - 추후 2번째 라이브러리인 python-injector를 사용해 볼 의향이 있습니다.
  - python-injector의 사용 체감이 좋다면, 라이브러리를 교체할 예정입니다.

## Linked Issues
- resolved #10 
